### PR TITLE
Allow linebreaks in source (classic Markdown style)

### DIFF
--- a/lib/Skriv/Markup/Html/Config.php
+++ b/lib/Skriv/Markup/Html/Config.php
@@ -112,6 +112,8 @@ class Config extends \WikiRenderer\Config  {
 			'addFootnotes'		=> false,
 			'codeInlineStyles'	=> false,
 			'debugMode'		=> false,
+			'debugMode'		=> false,
+			'softLinebreaks' 	=> false,
 		);
 		// processing of specified parameters
 		if (isset($param['shortenLongUrl']) && $param['shortenLongUrl'] === false)
@@ -149,6 +151,10 @@ class Config extends \WikiRenderer\Config  {
 			$this->_params['codeInlineStyles'] = true;
 		if (isset($param['debugMode']) && $param['debugMode'] === true)
 			$this->_params['debugMode'] = true;
+		if (isset($param['softLinebreaks']) && $param['softLinebreaks'] === true) {
+			$this->_params['softLinebreaks'] = true;
+			$this->simpletags = array('-/-' => '<br />');
+		}
 		// configuration of extensions
 		foreach ($this->_extensions as $extensionName => $defaultConf) {
 			if (isset($param[$extensionName]) && is_bool($param[$extensionName]))

--- a/lib/Skriv/Markup/Html/Config.php
+++ b/lib/Skriv/Markup/Html/Config.php
@@ -112,7 +112,6 @@ class Config extends \WikiRenderer\Config  {
 			'addFootnotes'		=> false,
 			'codeInlineStyles'	=> false,
 			'debugMode'		=> false,
-			'debugMode'		=> false,
 			'softLinebreaks' 	=> false,
 		);
 		// processing of specified parameters

--- a/lib/Skriv/Markup/Html/Paragraph.php
+++ b/lib/Skriv/Markup/Html/Paragraph.php
@@ -9,6 +9,7 @@ class Paragraph extends \WikiRenderer\Block {
 	protected $_closeTag = '</p>';
 	/** Attribute used to manage carriage-returns inside paragraphs. */
 	private $_firstLine = true;
+	private $_linePrefix = "<br />";
 
 	/**
 	 * Detection of paragraphs.
@@ -40,9 +41,15 @@ class Paragraph extends \WikiRenderer\Block {
 	protected function _renderInlineTag($string) {
 		$string = $this->engine->inlineParser->parse($string);
 		// handling of carriage-returns inside paragraphs
-		$string = (!$this->_firstLine) ? "<br />$string" : $string;
-		$this->_firstLine = false;
-		return ($string);
+		if ($this->_firstLine) {
+			if ($this->engine->getConfig()->getParam('softLinebreaks'))
+				$this->_linePrefix = " ";
+			else
+				$this->_linePrefix = "<br />";
+			$this->_firstLine = false;
+			return $string;
+		}
+		return $this->_linePrefix . $string;
 	}
 }
 


### PR DESCRIPTION
Hi, 

This is a small feature : the `softLinebreaks` config option allows Wikirenderer to treat linebreaks in blocks as normal formatting. So it doesn't output `<br />` at each new line.

The default configuration (`false`) stills behaves as normal Skriv, and `true` enables this feature. I've also added a symbol to create `br` tags when this mode is enabled : `-/-`. 

Thanks for any comment.

Lud
